### PR TITLE
fix(ci): skip create_and_enable_automerge job for Dependabot PRs

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   create_and_enable_automerge:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Dependabot PRs cannot access repository secrets (secrets.GH_TOKEN), causing the repo-sync/pull-request@v2 action to fail. Since Dependabot already creates pull requests automatically, this job is not needed for Dependabot-triggered pushes.

Adding if condition to skip this job for Dependabot branches, turning the consistent failure into a skip.

- close #299